### PR TITLE
[3532][IMP] product_plm_import: set uom field to be non-required field.

### DIFF
--- a/product_plm_import/wizards/product_plm_import.py
+++ b/product_plm_import/wizards/product_plm_import.py
@@ -21,7 +21,7 @@ FIELD_VALS = [
     ["procure_flag", "Procure flag", "char", True],
     ["item_type", "Item Type", "char", True],
     ["category", "Category", "char", True],
-    ["uom", "Unit of Material", "char", True],
+    ["uom", "Unit of Material", "char", False],
     ["description", "Description", "char", True],
     ["spec", "Spec", "char", False],
     ["drawing", "Drawing No", "char", False],


### PR DESCRIPTION
[3532](https://www.quartile.co/web#id=3532&cids=3&menu_id=505&action=1457&model=project.task&view_type=form)

Based on Client requirement that if in the import file from PLM doesn't includes with UOM, odoo should propose the UoM as unit. Currently if in the import file the uom is not declared, the import will be failed with error message 'Unit of Material is Missing'. This improvement will propose the uom as unit if the the file have such condition by set required field of the uom field is False.