### PR TITLE
[3921][FIX] product_plm_import: remove other encoding options than utf-8

### DIFF
--- a/product_plm_import/wizards/product_plm_import.py
+++ b/product_plm_import/wizards/product_plm_import.py
@@ -87,9 +87,7 @@ class ProductPlmImport(models.TransientModel):
         if not self.import_log_id.input_file and attachment:
             self.import_log_id.input_file = attachment
         field_defs = self._get_field_defs(FIELD_KEYS, FIELD_VALS)
-        sheet_fields, csv_iterator = self._load_import_file(
-            field_defs, ["cp932", "utf-8-sig", "utf-8"]
-        )
+        sheet_fields, csv_iterator = self._load_import_file(field_defs, ["utf-8"])
         vals_list = []
         # csv_iterator.line_num gets incremented by more than 1 when there is a text
         # field with a line break. Therefore, we need to use our own counter.


### PR DESCRIPTION
[3921](https://www.quartile.co/web#id=3921&cids=3&model=project.task&view_type=form)

There was a corner-case issue of data dcoding by cp932 wouldn't throw an exception when utf-8 file has been imported, resulting in rumbled characters in the imported content.

This commit fixes the issue by removing the other options (cp932 and utf-8-bom) than utf-8 to eliminate such kind of possibilities, as the imported file should always be encoded in utf-8.
