### PR TITLE
[4414][FIX] stock_move_line_move_location

### DIFF
--- a/stock_move_line_move_location/wizard/stock_move_location.py
+++ b/stock_move_line_move_location/wizard/stock_move_location.py
@@ -37,8 +37,8 @@ class StockMoveLocationWizard(models.TransientModel):
             return super()._prepare_wizard_move_lines(move_lines)
         # if need move only available qty per product on location
         for _product, ml in groupby(
-            sorted(move_lines, key=lambda r: (r.product_id, r.lot_id)),
-            lambda r: (r.product_id, r.lot_id),
+            sorted(move_lines, key=lambda r: (r.product_id, r.lot_id, r.owner_id)),
+            lambda r: (r.product_id, r.lot_id, r.owner_id),
         ):
             quant = self.env["stock.quant"]
             ml = list(ml)[0]
@@ -46,6 +46,8 @@ class StockMoveLocationWizard(models.TransientModel):
                 ml.product_id,
                 ml.location_dest_id,
                 ml.lot_id,
+                ml.package_id,
+                ml.owner_id,
                 strict=True,
             )
             if qty:
@@ -55,6 +57,8 @@ class StockMoveLocationWizard(models.TransientModel):
                     "max_quantity": qty,
                     "origin_location_id": ml.location_dest_id.id,
                     "lot_id": ml.lot_id.id,
+                    "package_id": ml.package_id.id,
+                    "owner_id": ml.owner_id.id,
                     "product_uom_id": ml.product_id.uom_id.id,
                     "custom": False,
                 }

--- a/stock_move_line_move_location/wizard/stock_move_location.py
+++ b/stock_move_line_move_location/wizard/stock_move_location.py
@@ -37,8 +37,11 @@ class StockMoveLocationWizard(models.TransientModel):
             return super()._prepare_wizard_move_lines(move_lines)
         # if need move only available qty per product on location
         for _product, ml in groupby(
-            sorted(move_lines, key=lambda r: (r.product_id, r.lot_id, r.owner_id)),
-            lambda r: (r.product_id, r.lot_id, r.owner_id),
+            sorted(
+                move_lines,
+                key=lambda r: (r.product_id, r.lot_id, r.owner_id, r.package_id),
+            ),
+            lambda r: (r.product_id, r.lot_id, r.owner_id, r.package_id),
         ):
             quant = self.env["stock.quant"]
             ml = list(ml)[0]


### PR DESCRIPTION
[4414](https://www.quartile.co/web#id=4414&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)

Fix there is only one transfer line proposed when I seleccted two stock move lines. 
![2024-04-09_12h06_58](https://github.com/qrtl/axls-custom/assets/101688144/6c5dad69-9b4b-4616-afac-70ddd109112b)
(one stock move line with owner and one stock move line without owner)
