### PR TITLE
[4121][FIX] stock_picking_validate_jobcan: show_jobcan_wf_number

### DIFF
--- a/stock_picking_validate_jobcan_wf/models/stock_picking.py
+++ b/stock_picking_validate_jobcan_wf/models/stock_picking.py
@@ -47,7 +47,11 @@ class StockPicking(models.Model):
     def _compute_show_jobcan_wf_number(self):
         for pick in self:
             pick.show_jobcan_wf_number = False
-            if pick.show_skip_jobcan_wf and not pick.skip_jobcan_wf:
+            if (
+                pick._is_outgoing()
+                and not pick._receipt_return_picking()
+                and not pick.skip_jobcan_wf
+            ):
                 pick.show_jobcan_wf_number = True
 
     def get_api_key(self, config):

--- a/stock_picking_validate_jobcan_wf/static/description/index.html
+++ b/stock_picking_validate_jobcan_wf/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION
[4121](https://www.quartile.co/web#id=4121&cids=3&model=project.task&view_type=form)

Before this commit, visibility of jobcan_wf_number field would depend on allocation of stock (the field would get hidden when owner stock was allocated), which was incorrect.