### PR TITLE
[5251][IMP] stock_lot_analytic: improve tests

### DIFF
--- a/stock_lot_analytic/tests/test_stock_lot_analytic.py
+++ b/stock_lot_analytic/tests/test_stock_lot_analytic.py
@@ -39,9 +39,7 @@ class TestStockLotAnalytic(TransactionCase):
 
     def test_stock_lot_analytic_with_incoming_picking(self):
         self.po.button_confirm()
-        picking = self.po.picking_ids.filtered(
-            lambda p: p.picking_type_id.code == "incoming"
-        )
+        picking = self.po.picking_ids
         self.assertTrue(picking, "No incoming picking was created.")
         picking.action_assign()
         for ml in picking.move_line_ids:

--- a/stock_lot_analytic/tests/test_stock_lot_analytic.py
+++ b/stock_lot_analytic/tests/test_stock_lot_analytic.py
@@ -1,29 +1,58 @@
 # Copyright 2023 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.addons.purchase_stock.tests.test_create_picking import TestCreatePicking
+from odoo.fields import Command
+from odoo.tests.common import TransactionCase
 
 
-class TestStockLotAnalytic(TestCreatePicking):
-    def test_stock_lot_analytic_with_incoming_picking(self):
-        self.product_id_1.tracking = "lot"
-        self.po = self.env["purchase.order"].create(self.po_vals)
-        self.po.order_line.write(
+class TestStockLotAnalytic(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = cls.env["product.product"].create(
             {
-                "analytic_distribution": {
-                    str(self.env.ref("analytic.analytic_agrolait").id): 100.0
-                }
+                "name": "Test Product",
+                "type": "product",
+                "tracking": "lot",
             }
         )
+        cls.analytic_account = cls.env.ref("analytic.analytic_agrolait")
+        cls.vendor = cls.env["res.partner"].create({"name": "Test Vendor"})
+        cls.po = cls.env["purchase.order"].create(
+            {
+                "partner_id": cls.vendor.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": cls.product.id,
+                            "product_qty": 2.0,
+                            "product_uom": cls.product.uom_id.id,
+                            "price_unit": 10.0,
+                            "analytic_distribution": {
+                                str(cls.analytic_account.id): 100.0
+                            },
+                        }
+                    )
+                ],
+            }
+        )
+
+    def test_stock_lot_analytic_with_incoming_picking(self):
         self.po.button_confirm()
-        self.picking = self.po.picking_ids[0]
-        for ml in self.picking.move_line_ids:
+        picking = self.po.picking_ids.filtered(
+            lambda p: p.picking_type_id.code == "incoming"
+        )
+        self.assertTrue(picking, "No incoming picking was created.")
+        picking.action_assign()
+        for ml in picking.move_line_ids:
             ml.lot_name = "test lot"
             ml.qty_done = ml.reserved_uom_qty
-        self.picking._action_done()
-        lot_analytic = self.env["stock.lot"].search(
-            [("product_id", "=", self.product_id_1.id), ("name", "=", "test lot")]
+        picking._action_done()
+        lot = self.env["stock.lot"].search(
+            [("product_id", "=", self.product.id), ("name", "=", "test lot")]
         )
         self.assertEqual(
-            lot_analytic.analytic_distribution, self.po.order_line.analytic_distribution
+            lot.analytic_distribution,
+            self.po.order_line.analytic_distribution,
+            "The analytic_distribution on the lot does not match the purchase order line.",
         )


### PR DESCRIPTION
Remove depending on the tests of purchase_stock to avoid the unnecessary issue when there is some changes in the custom module for the stock workflow.

[5251](https://www.quartile.co/web#id=5251&cids=3&model=project.task&view_type=form)