### PR TITLE
[5446][FIX] stock_picking_validate_jobcan_wf: prevent done state if an error occurs in a downstream operation during validation

### DIFF
--- a/stock_picking_validate_jobcan_wf/models/stock_picking.py
+++ b/stock_picking_validate_jobcan_wf/models/stock_picking.py
@@ -119,7 +119,8 @@ class StockPicking(models.Model):
         for pick in self.with_context(skip_immediate=True):
             try:
                 pick.move_ids._set_quantities_to_reservation()
-                pick.button_validate()
+                with self.env.cr.savepoint():
+                    pick.button_validate()
             except Exception as e:
                 # Avoid sending out the same message repeatedly.
                 if str(e) in pick.message_ids[:1].body:


### PR DESCRIPTION
[5446](https://www.quartile.co/web#id=5446&menu_id=517&cids=3&model=project.task&view_type=form)